### PR TITLE
Release 1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.3 (Jan 31, 2018)
+* (Fix) Resource `postgresql` PostgreSQL version validation.
+* (Fix) Use resource attributes to set PostgreSQL version for test purposes.
+
 ## 1.2.2 (Jan 16, 2018)
 * (New) PostgreSQL 10 support.
 * (New) Integration tests were migrated to InSpec.

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@express42.com'
 license          'MIT'
 description      'Installs and configures postgresql for clients or servers'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.2'
+version          '1.2.3'
 chef_version     '>= 12.5' if respond_to?(:chef_version)
 source_url       'https://github.com/express42/postgresql_lwrp' if respond_to?(:source_url)
 issues_url       'https://github.com/express42/postgresql_lwrp/issues' if respond_to?(:issues_url)

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -32,7 +32,7 @@ actions :create
 default_action :create
 
 attribute :cluster_name, kind_of: String, required: true
-attribute :cluster_version, kind_of: String, regex: [/\A(|\d.\d)\Z\z/], default: ''
+attribute :cluster_version, kind_of: String, regex: [/\A(1\d|9\.[1-6])\Z\z/], default: ''
 attribute :cookbook, kind_of: String, default: 'postgresql_lwrp'
 attribute :cluster_create_options, kind_of: Hash, default: {}
 attribute :configuration, kind_of: Hash, default: {}

--- a/test/fixtures/cookbooks/pgtest/recipes/create_database.rb
+++ b/test/fixtures/cookbooks/pgtest/recipes/create_database.rb
@@ -1,13 +1,13 @@
 include_recipe 'postgresql_lwrp::default'
 
 postgresql_database 'test01' do
-  in_version node['postgresql']['defaults']['server']['version']
+  in_version node['pgtest']['version']
   in_cluster 'main'
   owner 'test01'
 end
 
 postgresql_database 'test-02' do
-  in_version node['postgresql']['defaults']['server']['version']
+  in_version node['pgtest']['version']
   in_cluster 'main'
   owner 'test-02'
 end

--- a/test/fixtures/cookbooks/pgtest/recipes/create_user.rb
+++ b/test/fixtures/cookbooks/pgtest/recipes/create_user.rb
@@ -1,14 +1,14 @@
 include_recipe 'postgresql_lwrp::default'
 
 postgresql_user 'test01' do
-  in_version node['postgresql']['defaults']['server']['version']
+  in_version node['pgtest']['version']
   in_cluster 'main'
   encrypted_password 'test01'
   replication true
 end
 
 postgresql_user 'test-02' do
-  in_version node['postgresql']['defaults']['server']['version']
+  in_version node['pgtest']['version']
   in_cluster 'main'
   encrypted_password 'test-02'
   superuser true

--- a/test/fixtures/cookbooks/pgtest/recipes/install_ext.rb
+++ b/test/fixtures/cookbooks/pgtest/recipes/install_ext.rb
@@ -1,13 +1,13 @@
 include_recipe 'postgresql_lwrp::default'
 
 postgresql_extension 'cube' do
-  in_version node['postgresql']['defaults']['server']['version']
+  in_version node['pgtest']['version']
   in_cluster 'main'
   db 'test01'
 end
 
 pgxn_extension 'count_distinct' do
-  in_version node['postgresql']['defaults']['server']['version']
+  in_version node['pgtest']['version']
   in_cluster 'main'
   db 'test01'
   version '1.3.2'

--- a/test/fixtures/cookbooks/pgtest/recipes/master.rb
+++ b/test/fixtures/cookbooks/pgtest/recipes/master.rb
@@ -8,6 +8,7 @@ end
 
 postgresql 'main' do
   cluster_create_options('locale' => 'en_US.UTF-8')
+  cluster_version node['pgtest']['version']
   configuration(
     listen_addresses: '*',
     max_connections: 300,

--- a/test/fixtures/cookbooks/pgtest/recipes/slave.rb
+++ b/test/fixtures/cookbooks/pgtest/recipes/slave.rb
@@ -12,6 +12,7 @@ end
 
 postgresql 'slave' do
   cluster_create_options('locale' => 'en_US.UTF-8')
+  cluster_version node['pgtest']['version']
   configuration(
     port: '5433',
     listen_addresses: '*',

--- a/test/fixtures/cookbooks/pgtest/recipes/slave_init_nostart.rb
+++ b/test/fixtures/cookbooks/pgtest/recipes/slave_init_nostart.rb
@@ -8,6 +8,7 @@ end
 
 postgresql 'slave2' do
   cluster_create_options('locale' => 'ru_RU.UTF-8')
+  cluster_version node['pgtest']['version']
   configuration(
     port: '5434',
     listen_addresses: '*',

--- a/test/fixtures/cookbooks/pgtest/recipes/test.rb
+++ b/test/fixtures/cookbooks/pgtest/recipes/test.rb
@@ -1,4 +1,3 @@
-node.default['postgresql']['defaults']['server']['version'] = node['pgtest']['version']
 node.default['postgresql']['client']['version'] = node['pgtest']['version']
 
 include_recipe 'pgtest::master'


### PR DESCRIPTION
* (Fix) Resource `postgresql` PostgreSQL version validation.
* (Fix) Use resource attributes to set PostgreSQL version for test purposes.