### PR TITLE
Rename `params` method to `parameters` to prevent method conflict in Chef 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.4 (tbd)
+* (Fix) Rename `params` method in `postgresql_cloud_backup` for compatibility with Chef 13
+
 ## 1.2.3 (Jan 31, 2018)
 * (Fix) Resource `postgresql` PostgreSQL version validation.
 * (Fix) Use resource attributes to set PostgreSQL version for test purposes.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Description
 ===========
-This cookbook includes recipes and providers to install and configure postgresql database. This cookbook was tested with Postgresql 9.1, 9.2, 9.3, 9.4, 9.5, 9.6 & 10. 
+This cookbook includes recipes and providers to install and configure postgresql database. This cookbook was tested with Postgresql 9.1, 9.2, 9.3, 9.4, 9.5, 9.6 & 10.
 Supported platforms: Debian Jessie/Stretch and Ubuntu 14.04/16.04.
 
 Changelog
@@ -164,9 +164,9 @@ postgresql_cloud_backup 'main' do
   full_backup_time weekday: '*', month: '*', day: '*', hour: '3', minute: '0'
   # Data bag item should contain following keys for S3 protocol:
   # aws_access_key_id, aws_secret_access_key, wale_s3_prefix
-  params Chef::EncryptedDataBagItem.load('s3', 'secrets').to_hash.select {|i| i != "id"}
+  parameters Chef::EncryptedDataBagItem.load('s3', 'secrets').to_hash.select {|i| i != "id"}
   # Or just a hash, if you don't use data bags:
-  params { aws_access_key_id: 'access_key', aws_secret_access_key: 'secret_key', wale_s3_prefix: 's3_prefix' }
+  parameters { aws_access_key_id: 'access_key', aws_secret_access_key: 'secret_key', wale_s3_prefix: 's3_prefix' }
   protocol 's3'
   # In case you need to prepend wal-e with, for example, traffic limiter
   # you can use following method:

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@express42.com'
 license          'MIT'
 description      'Installs and configures postgresql for clients or servers'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.2.3'
+version          '1.2.4'
 chef_version     '>= 12.5' if respond_to?(:chef_version)
 source_url       'https://github.com/express42/postgresql_lwrp' if respond_to?(:source_url)
 issues_url       'https://github.com/express42/postgresql_lwrp/issues' if respond_to?(:issues_url)

--- a/providers/cloud_backup.rb
+++ b/providers/cloud_backup.rb
@@ -39,7 +39,7 @@ action :schedule do
   postgresql_path          = "/var/lib/postgresql/#{postgresql_version}/#{postgresql_instance_name}"
   wal_e_bin                = node['postgresql']['cloud_backup']['wal_e_bin']
   command_prefix           = new_resource.command_prefix
-  envdir_params            = new_resource.params
+  envdir_params            = new_resource.parameters
   full_backup_time         = new_resource.full_backup_time
 
   unsetted_required_params = params_validation(new_resource.protocol, envdir_params)

--- a/resources/cloud_backup.rb
+++ b/resources/cloud_backup.rb
@@ -41,7 +41,7 @@ attribute :protocol, kind_of: String,
                          !value.to_sym.match(/^(s3|swift|azure)$/).nil?
                        end,
                      }
-attribute :params, kind_of: Hash, required: true
+attribute :parameters, kind_of: Hash, required: true
 
 # Crontab command prefix to use with wal-e
 # e.g. for speed limit by trickle like `trickle -s -u 1024 envdir /etc/wal-e.d/...`


### PR DESCRIPTION
Fix for #46, if another name replacement for params is preferable, let me know.